### PR TITLE
Add periodic S3 export for DynamoDB tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .terraform
+dynamodb-s3export.zip

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.16.0"
   constraints = ">= 3.74.0, 4.16.0"

--- a/analytics.tf
+++ b/analytics.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "dynamodb_s3export" {
-  bucket = "${var.name}-dynamodb-exports"
+  bucket = "dynamodb-exports-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "example" {

--- a/analytics.tf
+++ b/analytics.tf
@@ -92,7 +92,7 @@ resource "aws_lambda_function" "dynamodb_s3export" {
 
   environment {
     variables = {
-      "S3_BUCKET_ARN"       = aws_s3_bucket.dynamodb_s3export.arn
+      "S3_BUCKET_NAME"       = aws_s3_bucket.dynamodb_s3export.id
       "DYNAMODB_TABLE_ARNS" = join(",", [aws_dynamodb_table.main.arn, aws_dynamodb_table.ipns.arn])
     }
   }

--- a/analytics.tf
+++ b/analytics.tf
@@ -1,0 +1,100 @@
+resource "aws_s3_bucket" "dynamodb_s3export" {
+  bucket = "${var.name}-dynamodb-exports"
+}
+
+resource "aws_cloudwatch_event_rule" "dynamodb_s3export" {
+  name                = "${var.name}-dynamodb-s3export-scheduler"
+  description         = "This CloudWatch event fires every day at noon and schedules DynamoDB exports to S3."
+  schedule_expression = "cron(0 12 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "dynamodb_s3export" {
+  rule = aws_cloudwatch_event_rule.dynamodb_s3export.name
+  arn  = aws_lambda_function.dynamodb_s3export.arn
+}
+
+resource "aws_iam_policy" "dynamodb_s3export" {
+  name        = "${var.name}-iam-policy-dynamodb-s3export"
+  description = "Allows to trigger dynamodb export to point in time and to access S3."
+  policy      = data.aws_iam_policy_document.dynamodb_s3export.json
+}
+
+# From here: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataExport.Requesting.html#DataExport.Requesting.Permissions
+data "aws_iam_policy_document" "dynamodb_s3export" {
+  version = "2012-10-17"
+
+  statement {
+    sid       = "AllowDynamoDBExportAction"
+    effect    = "Allow"
+    actions   = ["dynamodb:ExportTableToPointInTime"]
+    resources = [
+      aws_dynamodb_table.main.arn,
+      aws_dynamodb_table.ipns.arn
+    ]
+  }
+
+  statement {
+    sid     = "AllowWriteToDestinationBucket"
+    effect  = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = ["${aws_s3_bucket.dynamodb_s3export.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "name" {
+  role       = aws_iam_role.dynamodb_s3export_lambda.name
+  policy_arn = aws_iam_policy.dynamodb_s3export.arn
+}
+
+resource "aws_iam_role" "dynamodb_s3export_lambda" {
+  name               = "${var.name}-dynamodb-s3export-lambda"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "lambda_assume_role_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_lambda_function" "dynamodb_s3export" {
+  filename         = data.archive_file.dynamodb_s3export_lambda.output_path
+  function_name    = "${var.name}-dynamodb-s3export"
+  role             = aws_iam_role.dynamodb_s3export_lambda.arn
+  handler          = "dynamodb-s3export.lambda_handler"
+  source_code_hash = data.archive_file.dynamodb_s3export_lambda.output_base64sha256
+  runtime          = "python3.9"
+
+  environment {
+    variables = {
+      "S3_BUCKET_ARN"       = aws_s3_bucket.dynamodb_s3export.arn
+      "DYNAMODB_TABLE_ARNS" = join(",", [aws_dynamodb_table.main.arn, aws_dynamodb_table.ipns.arn])
+    }
+  }
+}
+
+data "archive_file" "dynamodb_s3export_lambda" {
+  type        = "zip"
+  source_file = "${path.module}/dynamodb-s3export.py"
+  output_path = "${path.module}/dynamodb-s3export.zip"
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.dynamodb_s3export.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.dynamodb_s3export.arn
+}

--- a/analytics.tf
+++ b/analytics.tf
@@ -2,6 +2,19 @@ resource "aws_s3_bucket" "dynamodb_s3export" {
   bucket = "${var.name}-dynamodb-exports"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "example" {
+  bucket = aws_s3_bucket.dynamodb_s3export.id
+
+  rule {
+    id     = "data-retention"
+    status = "Enabled"
+
+    expiration {
+      days = 7
+    }
+  }
+}
+
 resource "aws_cloudwatch_event_rule" "dynamodb_s3export" {
   name                = "${var.name}-dynamodb-s3export-scheduler"
   description         = "This CloudWatch event fires every day at noon and schedules DynamoDB exports to S3."

--- a/dynamodb-s3export.py
+++ b/dynamodb-s3export.py
@@ -15,20 +15,20 @@ def lambda_handler(event, context):
     logger.debug(f"Event {event}")
     logger.debug(f"Context {context}")
 
-    s3_bucket_arn = os.environ['S3_BUCKET_ARN']
+    s3_bucket_name = os.environ['S3_BUCKET_NAME']
     dynamodb_table_arns = os.environ['DYNAMODB_TABLE_ARNS']
 
-    logger.debug(f"S3_BUCKET_ARN: {s3_bucket_arn}")
+    logger.debug(f"S3_BUCKET_NAME: {s3_bucket_name}")
     logger.debug(f"DYNAMODB_TABLE_ARNS: {dynamodb_table_arns}")
 
     for dynamodb_table_arn in dynamodb_table_arns.split(","):
         # build prefix like: table_name/2022-08-11
         s3_prefix = f'{dynamodb_table_arn.split("/")[-1]}/{datetime.datetime.now().strftime("%Y-%m-%d")}'
 
-        logger.info(f"Triggering export of table {dynamodb_table_arn} to bucket {s3_bucket_arn}/{s3_prefix}")
+        logger.info(f"Triggering export of table {dynamodb_table_arn} to bucket {s3_bucket_name}/{s3_prefix}")
         response = client_dynamodb.export_table_to_point_in_time(
             TableArn=dynamodb_table_arn,
-            S3Bucket=s3_bucket_arn,
+            S3Bucket=s3_bucket_name,
             S3Prefix=s3_prefix,
             ExportFormat='DYNAMODB_JSON'
         )

--- a/dynamodb-s3export.py
+++ b/dynamodb-s3export.py
@@ -1,0 +1,36 @@
+import os
+import boto3
+import logging
+import datetime
+
+# Initialize logger
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+# Create AWS clients
+client_dynamodb = boto3.client('dynamodb')
+
+
+def lambda_handler(event, context):
+    logger.debug(f"Event {event}")
+    logger.debug(f"Context {context}")
+
+    s3_bucket_arn = os.environ['S3_BUCKET_ARN']
+    dynamodb_table_arns = os.environ['DYNAMODB_TABLE_ARNS']
+
+    logger.debug(f"S3_BUCKET_ARN: {s3_bucket_arn}")
+    logger.debug(f"DYNAMODB_TABLE_ARNS: {dynamodb_table_arns}")
+
+    for dynamodb_table_arn in dynamodb_table_arns.split(","):
+        # build prefix like: table_name/2022-08-11
+        s3_prefix = f'{dynamodb_table_arn.split("/")[-1]}/{datetime.datetime.now().strftime("%Y-%m-%d")}'
+
+        logger.info(f"Triggering export of table {dynamodb_table_arn} to bucket {s3_bucket_arn}/{s3_prefix}")
+        response = client_dynamodb.export_table_to_point_in_time(
+            TableArn=dynamodb_table_arn,
+            S3Bucket=s3_bucket_arn,
+            S3Prefix=s3_prefix,
+            ExportFormat='DYNAMODB_JSON'
+        )
+        logger.info(f"DynamoDB export response: {response}")
+    logger.info(f"Exports done.")


### PR DESCRIPTION
Hi @guseggert,

I had some time today and thought of giving the periodic S3 export a go. This should address issue #9.

Presumably, there are parts in this PR that are not in line with how things are done around here (e.g., resource naming, language/structure of lambdas, etc.). So, if that's the case, feel free to just take the parts you like and close this PR.

IIRC, the `main` table had a size of ~200GB. So, I guess, the lambda should remove the export `now() - 7d`. The point in time recovery still allows recovering data from the past ~30d.